### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the new GitHub Certifications program.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This PR adds the new "GitHub Skills" activity requested in Issue #6. It updates the in-memory activities database in `src/app.py` to include the new activity (description, schedule, capacity). This will make the activity visible in the frontend activities list and signup form.

Closes #6.